### PR TITLE
Fix for mercurial-4.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
     - TOXENV=py35
     - TOXENV=hg35
     - TOXENV=hg36
+    - TOXENV=hg41
     - TOXENV=coverage
 install: pip install docutils tox
 script: tox

--- a/src/diff_highlight.py
+++ b/src/diff_highlight.py
@@ -94,7 +94,10 @@ def uisetup(ui):
     def colorconfig(orig, *args, **kwargs):
         ret = orig(*args, **kwargs)
 
-        styles = color._styles
+        try:
+            from mercurial.color import _styles as styles
+        except ImportError:
+            styles = color._styles
         if INSERT_EMPH not in styles:
             styles[INSERT_EMPH] = styles[INSERT_NORM] + ' inverse'
 

--- a/tests/test_diff_highlight.py
+++ b/tests/test_diff_highlight.py
@@ -7,7 +7,10 @@ else:
     import unittest
 
 if sys.version_info < (3, 0):
-    from hgext import color
+    try:
+        from mercurial import color
+    except ImportError:
+        from hgext import color
     from diff_highlight import colorui
     from mercurial.util import version as mercurial_version
 else:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py26,py27,py32,py33,py34,py35,hg35,hg36
+envlist=py26,py27,py32,py33,py34,py35,hg35,hg36,hg41
 
 [testenv]
 deps=
@@ -62,6 +62,12 @@ basepython= python2.7
 deps=
     {[testenv:py3_common]deps}
     mercurial<3.7
+
+[testenv:hg41]
+basepython= python2.7
+deps=
+    {[testenv:py3_common]deps}
+    mercurial<4.2
 
 [testenv:coverage]
 basepython= python2.7


### PR DESCRIPTION
`hgext.color._styles` is moved to `mercurial.color._styles` in Mercurial 4.1